### PR TITLE
make secrets private to remove from state, and dict.get instead of direct access for env var

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ class DemoSlackCommandBot(SlackCommandBot):
         """Customize this method the way you want your bot to interact with the command."""
 
         data: dict = request.form
-        client = slack.WebClient(token=self.bot_token)
+        client = slack.WebClient(token=self._bot_token)
         client.chat_postMessage(channel=data.get("channel_id"), text="Testing send msg")
         return "Hey there! command was received successfully", 200
 


### PR DESCRIPTION
make secrets private to remove from state, and dict.get instead of direct access for env var

- rn secrets are available in state, this PR fixes that.
- instead of os.environ[key] move to os.environ.get('key') so app doesn't fail if key is not available - this will be helpful in writing manageable code 